### PR TITLE
Update pre-merge.yml update orch-ci version

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -17,7 +17,7 @@ jobs:
   pre-merge-pipeline:
     permissions:
       contents: read
-    uses: open-edge-platform/orch-ci/.github/workflows/pre-merge.yml@bf82f7924caaac6ba2f388b6ec6ac4edd65f48ee  # 2026.1.1
+    uses: open-edge-platform/orch-ci/.github/workflows/pre-merge.yml@b6610539eb98ed7bd5903e6629e48c1da39d883b  # 2026.1.1
     with:
       bootstrap_tools: "go,gotools,golangci-lint2,helm,yq,buf,opa"
       run_security_scans: true


### PR DESCRIPTION
This pull request updates the CI workflow reference in `.github/workflows/pre-merge.yml` to use a newer version of the shared pipeline.

CI/CD pipeline update:

* Updated the `pre-merge-pipeline` job to reference a newer commit (`b6610539eb98ed7bd5903e6629e48c1da39d883b`) of the shared workflow from `open-edge-platform/orch-ci`, ensuring the latest pipeline logic and fixes are used.