### PR TITLE
Fixing cooldown issue in code scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
     open-pull-requests-limit: 3
     commit-message:
       prefix: "[gomod] "
+    cooldown:
+      default-days: 7
     groups:
       dependencies:
         patterns:
@@ -27,3 +29,5 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "[gha] "
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
This pull request introduces a cooldown period to the Dependabot configuration, ensuring that updates for both Go modules and GitHub Actions are limited to once every 7 days. This helps reduce noise from frequent automated pull requests.

Dependabot configuration updates:

* Added a `cooldown` setting with `default-days: 7` to the Go modules update configuration in `.github/dependabot.yml`, limiting update frequency.
* Added a `cooldown` setting with `default-days: 7` to the GitHub Actions update configuration in `.github/dependabot.yml`, also limiting update frequency.