### PR TITLE
Enable post-merge security scans for tag creation

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -8,6 +8,8 @@ on:
     branches:
       - main
       - release-*
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow configuration. The change modifies the workflow trigger to also run on any tag push, in addition to the existing branch patterns.

- Updated `.github/workflows/post-merge.yml` to trigger the workflow on any tag push by adding a `tags` pattern under the `on` section.