### PR TITLE
Remove tag tigger on post-merge.yml

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -8,8 +8,6 @@ on:
     branches:
       - main
       - release-*
-    tags:
-      - '*'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This pull request makes a small change to the `.github/workflows/post-merge.yml` workflow configuration. The workflow will no longer be triggered by tags, only by pushes to the `main` or `release-*` branches and manual dispatches.